### PR TITLE
Adds starter for job title descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Collection of resources and tips for brand new alumni 📚🤓💪
 
 * [Getting a job (To do)](https://github.com/CodeClanAlumni/survival-guide/blob/master/getting-a-job.md)
 
+* [Jobs in tech] (https://github.com/CodeClanAlumni/survival-guide/blob/master/jobs-in-tech.md)
+
 * [Job Hunting (To do)](https://github.com/CodeClanAlumni/survival-guide/blob/master/while-job-hunting.md)
 
 * [Community](https://github.com/CodeClanAlumni/survival-guide/blob/master/community.md)

--- a/jobs-in-tech.md
+++ b/jobs-in-tech.md
@@ -5,7 +5,7 @@ It's worth making sure that you're applying to a role that sets you in the right
 
 ## Software developer
 
-## Tester
+## Test engineer
 
 ## QA engineer
 

--- a/jobs-in-tech.md
+++ b/jobs-in-tech.md
@@ -1,0 +1,18 @@
+## Jobs in Tech
+Below are some descriptions of the various types of roles that you might see when looking for a job. These descriptions are based on the experiences of alumni who have had them, and focus on what sorts of things you might expect from a junior level position. As with any industry, titles can have quite a fluid meaning and each company will attribute a slightly different set of responsibilities each title.
+
+It's worth making sure that you're applying to a role that sets you in the right direction given your career goals, or that you at least have a good understanding of what that type of job is likely to entail.
+
+## Software developer
+
+## Tester
+
+## QA engineer
+
+## Dev Ops engineer
+
+## Support engineer
+
+## Product owner
+
+## Project manager


### PR DESCRIPTION
## What?
This adds a place for us to put descriptions of the various types of jobs that a grad might go in to, as we've experienced them. It currently contains an intro and then headers for different job titles that I could think of.

## Why?
There's not much information at the point of graduation about the various types of roles available and where each might lead. It seems like sometimes people get into roles that don't involve much programming (when that's what they wanted to do) and are difficult to transition away from, without this being highlighted to them beforehand. Similarly, for people who want a role that doesn't involve programming but utilises that knowledge, it's hard to know what kinds of things exist.

There are descriptions of roles available elsewhere but I thought the thing that we could offer here that is different is an insight into what you might expect as a junior specifically, as well as some detail about the experiences of various alumni that have gone into these positions. We could potentially link these to the alumni stories when there are more of each.