### PR TITLE
add info to getting a job page - portfolios, github readmes, CV

### DIFF
--- a/getting-a-job.md
+++ b/getting-a-job.md
@@ -1,9 +1,25 @@
 # Getting a job
 
+## Your Portfolio Site
+
+While you are job hunting and unemployed, maintaining a portfolio site which shows off your work can be a great way of keeping on top of continued coding practice and is an excellent way to show off what you can do to prospective employers.
+
+[SkillCrush have a great guide on stuff you can put in there](https://skillcrush.com/2016/09/12/beginner-portfolio-guide/)
+[FreeCodeCamp has some good examples here](https://medium.freecodecamp.org/15-web-developer-portfolios-to-inspire-you-137fb1743cae)
+
+## Your GitHub Profile
+
+It's worth sprucing up your GitHub page and pinning the repos you're most keen for employers to see. Every important repo should have a good readme.
+[Here are some example awesome readmes](https://github.com/matiassingers/awesome-readme)
+[Here is a good readme template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)
 
 ## Salary
-
 
 Want to know how to negotiate on salary whether you are in the process of being hired or have been hired? [Here's a read on salary negotiation.](https://www.kalzumeus.com/2012/01/23/salary-negotiation/)
 
 And an ongoing open-source contribution of software developers salries from around the world, [here.](https://docs.google.com/spreadsheets/u/1/d/1pY64JMN8UnwEy4mIP4_gr4BhOAa6Il6o3CqA_j0wRdI/edit#gid=1922656675)
+
+## Your CV
+
+Your CV should be slightly tailored for each job you apply for. The best way of doing that is picking out key words from the job description and highlighting or repeating them back in your CV. For example, if it's a front end job based on JavaScript, make sure to emphasise the JS project you did at CodeClan and any other JS work you've done.
+


### PR DESCRIPTION
>_Let everyone know your intention with this pull request._ What information is it adding? Is it safe to add in a public space? 

## What?
Info on the job hunting page: 
 portfolios, github readmes, CV


## Why?
Getting a job after CodeClan is hard and important!


<!-- Context:
Is there an issue link for this pull request? 
Consider adding one to let everyone know what you intend to work on.
[Issue #](https://github.com/CodeClanAlumni/survival-guide/issues/X)
-->
