### PR TITLE
Add podcasts and organise twitter profiles

### DIFF
--- a/pages/community.md
+++ b/pages/community.md
@@ -41,33 +41,59 @@ Other community Slack channels include:
 Twitter has its ups and downs, but a lot of interesting people use it to share tech news, insights into working in the industry and cool projects they're working on. Some recommended follows:
 
 * https://twitter.com/CodeClanScot/lists/codeclanners - list of CodeClan folk - add yourself!
-* https://twitter.com/jesslynnrose - tech culture, developer relations, webinars for newbies
-* https://twitter.com/sehurlburt - startups/business, tech culture
-* https://twitter.com/aprilwensel - founder of Compassionate Coding
-* https://twitter.com/Gaohmee - games development
-* https://twitter.com/jennschiffer - web development, works on Glitch
-* https://twitter.com/wesbos - full stack developer, tutorials on React & CSS Grid
-* https://twitter.com/vaidehijoshi - writes about computer science for beginners
-* https://twitter.com/ChloeCondon - developer evangelist and career changer from actress to tech
-* https://twitter.com/deefex - software testing
-* https://twitter.com/webdevlaw - tech ethics and tech law/policy specialist
-* https://twitter.com/BecomingDataSci - data science
-* https://twitter.com/jensimmons - CSS guru
-* https://twitter.com/sailorhg - zines about computers
-* https://twitter.com/lara_hogan - tech culture and management
-* https://twitter.com/b0rk - infrastructure and linux stuff for newbies
-* https://twitter.com/chiuki - Android, public speaking tips
-* https://twitter.com/beep - responsive web design, tech ethics
-* https://twitter.com/patio11 - business and financial side of tech, also Japanese culture
-* https://twitter.com/dan_abramov - works on React js and is community-oriented
-* https://twitter.com/sophiebits - also works on React js, active LGBTQ advocate, community focused
-* https://twitter.com/sarahmei - big name in the Ruby world
-* https://twitter.com/sandimetz - another big name in Ruby
-* https://twitter.com/chrisalbon - data scientist and writer of machine learning
-* https://twitter.com/histoftech - technology historian
-* https://twitter.com/rtfeldman - author of Elm in Action
-* https://twitter.com/alicegoldfuss - coolest conference speaker, works at Github
-* https://twitter.com/mpjme - does great JS tutorials on youtube
+
+### Tech culture
+
+* [Jess Lynn Rose](https://twitter.com/jesslynnrose) - tech culture, developer relations, webinars for newbies
+* [Stephanie Hurlbut](https://twitter.com/sehurlburt) - startups/business, tech culture
+* [April Wensel](https://twitter.com/aprilwensel) - founder of Compassionate Coding
+* [Amy (Sailor Mercury)](https://twitter.com/sailorhg)- zines about computers
+* [Lara Hogan](https://twitter.com/lara_hogan) - tech culture and management
+* [Mar Hicks](https://twitter.com/histoftech) - technology historian
+* [Patrick McKenzie](https://twitter.com/patio11) - business and financial side of tech, also Japanese culture
+* [Chloe Condon](https://twitter.com/ChloeCondon) - developer evangelist and career changer from actress to tech
+* [Web Dev Law](https://twitter.com/webdevlaw) - tech ethics and tech law/policy specialist
+* [Julia Evans](https://twitter.com/b0rk) - infrastructure and linux stuff for newbies
+
+### Web/JS
+* [Dan Abramov](https://twitter.com/dan_abramov) - works on React js and is community-oriented
+* [Sophie Alpert](https://twitter.com/sophiebits) - also works on React js, active LGBTQ advocate, community focused
+* [Mattias Petter Johansson](https://twitter.com/mpjme) - does great JS tutorials on youtube
+* [Jen Simmons](https://twitter.com/jensimmons) - CSS guru
+* [Jenn Schiffer](https://twitter.com/jennschiffer) - web development, works on Glitch
+* [Wes Bos](https://twitter.com/wesbos) - full stack developer, tutorials on React & CSS Grid
+* [Richard Feldman](https://twitter.com/rtfeldman) - author of Elm in Action
+* [Ethan Marcotte](https://twitter.com/beep) - responsive web design, tech ethics
+
+### Ruby
+* [Sarah Mei](https://twitter.com/sarahmei) - big name in the Ruby world
+* [Sandi Metz](https://twitter.com/sandimetz) - another big name in Ruby
+
+### Games
+* [Jennifer Scheurle](https://twitter.com/Gaohmee) - games development
+
+### Testing
+* [Del Dewar](https://twitter.com/deefex) - software testing
+
+### DevOps
+* [Alice Goldfuss](https://twitter.com/alicegoldfuss) - coolest conference speaker, works at Github
+
+### Data
+* [Chris Albon](https://twitter.com/chrisalbon) - data scientist and writer of machine learning
+* [Renee](https://twitter.com/BecomingDataSci)- data science
+
+### Computer Science
+* [Vaidehi Joshi](https://twitter.com/vaidehijoshi) - writes about computer science for beginners
+* [Saron Yitbarek](https://twitter.com/saronyitbarek) - founder of CodeNewbies, base.cs podcaster
+
+### Android
+* [Chiu-Ki Chan](https://twitter.com/chiuki) - Android, public speaking tips
+
+
+## Podcasts
+* [base.cs](https://www.codenewbie.org/basecs) - teaches computer science topics, _actually_ makes it enjoyable
+* [Learn to Code with Me](https://learntocodewith.me/podcast/) - includes many people's journeys into the tech industry and basic survival guides for the industry
+* [Frontend Happy Hour](https://frontendhappyhour.com/) - [*warning* - includes alcohol consumption] - discusses fairly advanced topics in the frontend world
 
 ## Get started with blogging or public speaking
 

--- a/pages/community.md
+++ b/pages/community.md
@@ -90,7 +90,7 @@ Twitter has its ups and downs, but a lot of interesting people use it to share t
 * [Chiu-Ki Chan](https://twitter.com/chiuki) - Android, public speaking tips
 
 
-## Podcasts
+## Podcasts
 * [base.cs](https://www.codenewbie.org/basecs) - teaches computer science topics, _actually_ makes it enjoyable
 * [Learn to Code with Me](https://learntocodewith.me/podcast/) - includes many people's journeys into the tech industry and basic survival guides for the industry
 * [Frontend Happy Hour](https://frontendhappyhour.com/) - [*warning* - includes alcohol consumption] - discusses fairly advanced topics in the frontend world


### PR DESCRIPTION
>_Let everyone know your intention with this pull request._ What information is it adding? Is it safe to add in a public space? 

## What?
Adds a podcasts section to the 'community' page and also re-organizes the twitter handles.


## Why?
I've been listening to some great podcasts lately and it's a good idea to share. The twitter section was getting hard to read so now has sections and people's names rather than a twitter link.


<!-- Context:
Is there an issue link for this pull request? 
Consider adding one to let everyone know what you intend to work on.
[Issue #](https://github.com/CodeClanAlumni/survival-guide/issues/X)
-->
