### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ $ ruby --version
 $ gem install bundler
 ```
 
+* Install the plugins ([Jekyll](https://jekyllrb.com/) and its dependencies)
+```
+$ bundle install
+```
+
 * Run locally
 ```
 $ bundle exec jekyll serve

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ $ ruby --version
 
 * Install the Bundler
 ```
-$ gem install Bundler
+$ gem install bundler
 ```
 
 * Run locally


### PR DESCRIPTION
## What?

Fixes `gem install` instruction in README

## Why?

Current instruction gives error:
```
ERROR:  Could not find a valid gem 'Bundler' (>= 0) in any repository
ERROR:  Possible alternatives: bundler
```
