### PR TITLE
change raw URL text to links

### DIFF
--- a/pages/learning-resources.md
+++ b/pages/learning-resources.md
@@ -9,93 +9,95 @@ As you can imagine, there is a huge amount of coding info online. The alumni hav
 
 #### Non-language Specific
 
-* [Online Tutorials](#online-coding-tutorials)
-* [Blogs](#useful-and-interesting-tech-blogs)
-* [Podcasts](#podcasts-of-note)
-* [Computer Science](#computer-science)
-* [Just Generally Useful](#just-generally-useful)
+- [Online Tutorials](#online-coding-tutorials)
+- [Blogs](#useful-and-interesting-tech-blogs)
+- [Podcasts](#podcasts-of-note)
+- [Computer Science](#computer-science)
+- [Just Generally Useful](#just-generally-useful)
 
 #### Language Specific
-* [Go](#go-online-resources)
-* [JavaScript](#javascript-online-resources)
-* [Ruby](#ruby-online-resources)
-* [Ruby on Rails](#rails-online-resources)
-* [SQL](#sql)
+
+- [Go](#go-online-resources)
+- [JavaScript](#javascript-online-resources)
+- [Ruby](#ruby-online-resources)
+- [Ruby on Rails](#rails-online-resources)
+- [SQL](#sql)
 
 ## Online coding tutorials
 
-* Codebar - https://codebar.io/
-* Codecademy - https://www.codecademy.com/
-* Coursera - https://www.coursera.org/
-* Udemy - https://www.udemy.com/
-* Khan Academy - https://www.khanacademy.org/
-* Treehouse (subscription based but excellent) - https://teamtreehouse.com/
+- [Codebar](https://codebar.io/)
+- [Codecademy](https://www.codecademy.com/)
+- [Coursera](https://www.coursera.org/)
+- [Udemy](https://www.udemy.com/)
+- [Khan Academy](https://www.khanacademy.org/)
+- [Treehouse](https://teamtreehouse.com/) (subscription based but excellent)
 
 ## Useful and interesting tech blogs
-* FreeCodeCamp - https://medium.freecodecamp.org/
-* Pretty much everything on the tech track in Medium - https://medium.com/topic/technology
-* Google Developer Blog - https://developers.googleblog.com/
-* Github blog - https://blog.github.com/
-* Open Data Institute - https://theodi.org/knowledge-opinion/blog/
-* Information is Beautiful - https://informationisbeautiful.net/
+
+- [FreeCodeCamp](https://medium.freecodecamp.org/)
+- Pretty much everything on the [tech track in Medium](https://medium.com/topic/technology)
+- [Google Developer Blog](https://developers.googleblog.com/)
+- [Github blog](https://blog.github.com/)
+- [Open Data Institute](https://theodi.org/knowledge-opinion/blog/)
+- [Information is Beautiful](https://informationisbeautiful.net/)
 
 ## Podcasts of note
 
-* Code Newbie - https://www.codenewbie.org/podcast
-* Greater than Code - http://www.greaterthancode.com/
+- [Code Newbie](https://www.codenewbie.org/podcast)
+- [Greater than Code](http://www.greaterthancode.com/)
 
-## Computer science
-* Crash course computer science - https://youtu.be/tpIctyqH29Q
-* Design patterns - https://sourcemaking.com/design_patterns
+## Computer Science
+
+- [Crash course computer science](https://youtu.be/tpIctyqH29Q)
+- [Sourcemaking](https://sourcemaking.com/design_patterns) (Design patterns)
 
 ## Just generally useful
 
-* The Git book - https://git-scm.com/book/en/v2
-* How to level up as a Junior Dev - https://24ways.org/2017/levelling-up-for-junior-developers/
+- [The Git book](https://git-scm.com/book/en/v2)
+- [How to Level Up as a Junior Dev](https://24ways.org/2017/levelling-up-for-junior-developers/)
 
 ## Go online resources
 
-* Learn Go with tests - https://quii.gitbook.io/learn-go-with-tests
-* A tour of Go - https://tour.golang.org/
+- [Learn Go with tests](https://quii.gitbook.io/learn-go-with-tests)
+- [A tour of Go](https://tour.golang.org/)
 
 ## JavaScript online resources
 
-* The Modern JavaScript Tutorial - http://javascript.info/
-* JavaScript 30 - https://javascript30.com/
-* Eloquent JavaScript - https://eloquentjavascript.net/
-* JSConf Videos - https://www.youtube.com/user/jsconfeu
+- [The Modern JavaScript Tutorial](http://javascript.info/)
+- [JavaScript 30](https://javascript30.com/)
+- [Eloquent JavaScript](https://eloquentjavascript.net/)
+- [JSConf Videos](https://www.youtube.com/user/jsconfeu)
 
 ## Ruby online resources
 
 ### Guides and Documentation
 
-* Ruby Documentation - https://ruby-doc.org/
-* Learn Ruby The Hard Way - https://learnrubythehardway.org/
-* Codecademy Ruby Tutorial - https://www.codecademy.com/learn/learn-ruby
-* Why's Poignant Guide To Ruby - https://poignant.guide/
-* Ruby Monk https://rubymonk.com/
-* Rubular, a regular expression editor - http://rubular.com/
-
+- [Ruby Documentation](https://ruby-doc.org/)
+- [Learn Ruby The Hard Way](https://learnrubythehardway.org/)
+- [Codecademy Ruby Tutorial](https://www.codecademy.com/learn/learn-ruby)
+- [Why's Poignant Guide To Ruby](https://poignant.guide/)
+- [Ruby Monl](https://rubymonk.com/)
+- [Rubular, a regular expression editor](http://rubular.com/)
 
 ### Practice
 
-* Repl.it, a browser-based Ruby emulator- https://repl.it/
-* Ruby Warrior - https://www.bloc.io/ruby-warrior#/
-* Codewars, Ruby for beginners - https://www.codewars.com/collections/ruby-for-beginners
-* Exercism.io, Ruby katas - https://exercism.io/tracks/ruby
+- [Repl.it](https://repl.it/), a browser-based Ruby emulator
+- [Ruby Warrior](https://www.bloc.io/ruby-warrior#/)
+- [Codewars, Ruby for beginners](https://www.codewars.com/collections/ruby-for-beginners)
+- [Exercism.io, Ruby katas](https://exercism.io/tracks/ruby)
 
 ## Rails online resources
 
 ### Guides and Documentation
 
-* Rails Documentation - https://guides.rubyonrails.org/
-* Ruby on Rails Tutorial, Michael Hartl - https://www.railstutorial.org/book
-* Codecademy Rails Course - https://www.codecademy.com/learn/learn-rails
-* TutorialsPoint Rails Course - https://www.tutorialspoint.com/ruby-on-rails/
+- [Rails Documentation](https://guides.rubyonrails.org/)
+- [Ruby on Rails Tutorial](https://www.railstutorial.org/book), Michael Hartl
+- [Codecademy Rails Course](https://www.codecademy.com/learn/learn-rails)
+- [TutorialsPoint Rails Course](https://www.tutorialspoint.com/ruby-on-rails/)
 
-*Note - I've found the [Treehouse Rails track](https://teamtreehouse.com/tracks/rails-development) to be excellent, but it's paid for. You can get a week free before stumping up cash. Worth it! - Claire*
+_Note - I've found the [Treehouse Rails track](https://teamtreehouse.com/tracks/rails-development) to be excellent, but it's paid for. You can get a week free before stumping up cash. Worth it! - Claire_
 
 ## SQL
 
-* SQL Bolt - Learn SQL - https://sqlbolt.com/
-* W3Schools SQL Tutorial - https://www.w3schools.com/sql/
+- [SQL Bolt](https://sqlbolt.com/)
+- [W3Schools SQL Tutorial](https://www.w3schools.com/sql/)


### PR DESCRIPTION
>_Let everyone know your intention with this pull request._ What information is it adding? Is it safe to add in a public space? 

## What?

Changes raw URL text to standard MarkDown `[Title](https://url.com)` format

## Why?

Jekyll doesn't seem to automatically convert these like GitHub does.