### PR TITLE
add generated table of contents

### DIFF
--- a/pages/community.md
+++ b/pages/community.md
@@ -4,10 +4,14 @@ layout: default
 ---
 
 # Community
+{:.no_toc}
 
 Both while you're looking for your first job after CodeClan and once you've started it, getting involved in the developer community can be a great way to meet new people, learn new things and further your career.
 
 Some of us find it draining to go to lots of social events and speak to lots of new people, but there are many ways to stay involved - Chloe Condon's post [The Ambivert's Guide to Staying in Tech](https://www.coursereport.com/blog/the-ambivert-s-guide-to-staying-in-tech) has tips for extroverts, introverts, and those in between.
+
+- Table of Contents
+{:toc}
 
 ## Slack channels
 

--- a/pages/learning-resources.md
+++ b/pages/learning-resources.md
@@ -4,26 +4,16 @@ layout: default
 ---
 
 # Coding Resources
+{:.no_toc}
 
 As you can imagine, there is a huge amount of coding info online. The alumni have gathered some of their favourite resources, feel free to add your own.
 
-#### Non-language Specific
+- Table of Contents
+{:toc}
 
-- [Online Tutorials](#online-coding-tutorials)
-- [Blogs](#useful-and-interesting-tech-blogs)
-- [Podcasts](#podcasts-of-note)
-- [Computer Science](#computer-science)
-- [Just Generally Useful](#just-generally-useful)
+## Non-language specific
 
-#### Language Specific
-
-- [Go](#go-online-resources)
-- [JavaScript](#javascript-online-resources)
-- [Ruby](#ruby-online-resources)
-- [Ruby on Rails](#rails-online-resources)
-- [SQL](#sql)
-
-## Online coding tutorials
+### Online coding tutorials
 
 - [Codebar](https://codebar.io/)
 - [Codecademy](https://www.codecademy.com/)
@@ -32,7 +22,7 @@ As you can imagine, there is a huge amount of coding info online. The alumni hav
 - [Khan Academy](https://www.khanacademy.org/)
 - [Treehouse](https://teamtreehouse.com/) (subscription based but excellent)
 
-## Useful and interesting tech blogs
+### Useful and interesting tech blogs
 
 - [FreeCodeCamp](https://medium.freecodecamp.org/)
 - Pretty much everything on the [tech track in Medium](https://medium.com/topic/technology)
@@ -41,42 +31,44 @@ As you can imagine, there is a huge amount of coding info online. The alumni hav
 - [Open Data Institute](https://theodi.org/knowledge-opinion/blog/)
 - [Information is Beautiful](https://informationisbeautiful.net/)
 
-## Podcasts of note
+### Podcasts of note
 
-* [Code Newbie](https://www.codenewbie.org/podcast)
-* [Greater than Code](http://www.greaterthancode.com/)
-* [base.cs](https://www.codenewbie.org/basecs) - teaches computer science topics, _actually_ makes it enjoyable
-* [Learn to Code with Me](https://learntocodewith.me/podcast/) - includes many people's journeys into the tech industry and basic survival guides for the industry
-* [Frontend Happy Hour](https://frontendhappyhour.com/) - [*warning* - includes alcohol consumption] - discusses fairly advanced topics in the frontend world
-* [The Cynical Developer](https://cynicaldeveloper.com/) - dev-based discussions on lots of topics, including technologies, languages, career skills, soft skills
-* [Weekly Dev Tips](http://www.weeklydevtips.com/) - short (~6min) episodes giving overviews of engineering topics
-* [The Changelog](https://changelog.com/podcasts) - a collection of podcasts, including on JavaScript, on start-up founders, Go, AI and lots more
+- [Code Newbie](https://www.codenewbie.org/podcast)
+- [Greater than Code](http://www.greaterthancode.com/)
+- [base.cs](https://www.codenewbie.org/basecs) - teaches computer science topics, _actually_ makes it enjoyable
+- [Learn to Code with Me](https://learntocodewith.me/podcast/) - includes many people's journeys into the tech industry and basic survival guides for the industry
+- [Frontend Happy Hour](https://frontendhappyhour.com/) - [*warning* - includes alcohol consumption] - discusses fairly advanced topics in the frontend world
+- [The Cynical Developer](https://cynicaldeveloper.com/) - dev-based discussions on lots of topics, including technologies, languages, career skills, soft skills
+- [Weekly Dev Tips](http://www.weeklydevtips.com/) - short (~6min) episodes giving overviews of engineering topics
+- [The Changelog](https://changelog.com/podcasts) - a collection of podcasts, including on JavaScript, on start-up founders, Go, AI and lots more
 
-## Computer Science
+### Computer Science
 
 - [Crash course computer science](https://youtu.be/tpIctyqH29Q)
 - [Sourcemaking](https://sourcemaking.com/design_patterns) (Design patterns)
 
-## Just generally useful
+### Just generally useful
 
 - [The Git book](https://git-scm.com/book/en/v2)
 - [How to Level Up as a Junior Dev](https://24ways.org/2017/levelling-up-for-junior-developers/)
 
-## Go online resources
+## Language specific
+
+### Go online resources
 
 - [Learn Go with tests](https://quii.gitbook.io/learn-go-with-tests)
 - [A tour of Go](https://tour.golang.org/)
 
-## JavaScript online resources
+### JavaScript online resources
 
 - [The Modern JavaScript Tutorial](http://javascript.info/)
 - [JavaScript 30](https://javascript30.com/)
 - [Eloquent JavaScript](https://eloquentjavascript.net/)
 - [JSConf Videos](https://www.youtube.com/user/jsconfeu)
 
-## Ruby online resources
+### Ruby online resources
 
-### Guides and Documentation
+#### Guides and Documentation
 
 - [Ruby Documentation](https://ruby-doc.org/)
 - [Learn Ruby The Hard Way](https://learnrubythehardway.org/)
@@ -85,16 +77,16 @@ As you can imagine, there is a huge amount of coding info online. The alumni hav
 - [Ruby Monl](https://rubymonk.com/)
 - [Rubular, a regular expression editor](http://rubular.com/)
 
-### Practice
+#### Practice
 
 - [Repl.it](https://repl.it/), a browser-based Ruby emulator
 - [Ruby Warrior](https://www.bloc.io/ruby-warrior#/)
 - [Codewars, Ruby for beginners](https://www.codewars.com/collections/ruby-for-beginners)
 - [Exercism.io, Ruby katas](https://exercism.io/tracks/ruby)
 
-## Rails online resources
+### Rails online resources
 
-### Guides and Documentation
+#### Guides and Documentation
 
 - [Rails Documentation](https://guides.rubyonrails.org/)
 - [Ruby on Rails Tutorial](https://www.railstutorial.org/book), Michael Hartl
@@ -103,7 +95,7 @@ As you can imagine, there is a huge amount of coding info online. The alumni hav
 
 _Note - I've found the [Treehouse Rails track](https://teamtreehouse.com/tracks/rails-development) to be excellent, but it's paid for. You can get a week free before stumping up cash. Worth it! - Claire_
 
-## SQL
+### SQL
 
 - [SQL Bolt](https://sqlbolt.com/)
 - [W3Schools SQL Tutorial](https://www.w3schools.com/sql/)


### PR DESCRIPTION
## What?

Adds automatically generated tables of contents to the Community and Learning Resources pages

## Why?

Because we can. Also it means sections can be added without having to also update the manually built ToC.

## Wow, really?

Yep. Markdown translation in Jekyll is handled by [kramdown](https://kramdown.gettalong.org/), which already generates selector IDs for headings. That's how we get anchor links like this: https://codeclanalumni.github.io/survival-guide/pages/learning-resources#javascript-online-resources I haven't added any new libraries here. Kramdown can just take all these generated IDs and [put them all in a list](https://kramdown.gettalong.org/converter/html.html#toc).

 tl;dr:

```
# Title
{:.no_toc}
<!-- We don't want the page title to appear in the table of contents -->

- TOC
{:toc}
<!-- We want the table of contents to be an unordered list, so we make an unordered list of one item (the text here doesn't matter) -->
<!-- kramdown will replace the unordered list on the line above the {:toc} tag with a generated TOC -->

## Another thing

## And another thing

Actual text content

### Not only that, but also
```

![Screenshot of generated table of contents](https://user-images.githubusercontent.com/1347511/49522957-ac103800-f8a0-11e8-99f8-b20a258212d3.png)

Pretty sick, right?
